### PR TITLE
make husky prepare not fail npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "typecheck": "tsc --noEmit",
         "codegen": "graphql-codegen --config codegen.ts",
         "codegen:watch": "graphql-codegen --config codegen.ts --watch",
-        "prepare": "husky install",
+        "prepare": "husky install || true",
         "prisma:generate": "prisma generate",
         "prisma:push": "prisma db push",
         "prisma:studio": "prisma studio"


### PR DESCRIPTION
make husky prepare not fail npm install by adding || true to the prepare script