### PR TITLE
change eventId to id and add invariant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
                 "graphql-scalars": "^1.24.2",
                 "graphql-yoga": "^5.14.0",
                 "jsonwebtoken": "^9.0.2",
+                "tiny-invariant": "^1.3.3",
                 "zod": "^3.25.76"
             },
             "devDependencies": {
@@ -13590,6 +13591,12 @@
             "engines": {
                 "node": ">=16"
             }
+        },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "license": "MIT"
         },
         "node_modules/tinyexec": {
             "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "graphql-scalars": "^1.24.2",
         "graphql-yoga": "^5.14.0",
         "jsonwebtoken": "^9.0.2",
+        "tiny-invariant": "^1.3.3",
         "zod": "^3.25.76"
     },
     "devDependencies": {

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -28,7 +28,7 @@ export type Scalars = {
 /** Input for adding a timestamp to a loggable event */
 export type AddTimestampToEventMutationInput = {
     /** ID of the loggable event to add timestamp to */
-    eventId: Scalars['ID']['input'];
+    id: Scalars['ID']['input'];
     /** ISO string timestamp to add to the event */
     timestamp: Scalars['DateTime']['input'];
 };
@@ -256,7 +256,7 @@ export type Query = {
 /** Input for removing a timestamp from a loggable event */
 export type RemoveTimestampFromEventMutationInput = {
     /** ID of the loggable event to remove timestamp from */
-    eventId: Scalars['ID']['input'];
+    id: Scalars['ID']['input'];
     /** ISO string timestamp to remove from the event */
     timestamp: Scalars['DateTime']['input'];
 };

--- a/src/schema/loggableEvent/loggableEvent.graphql
+++ b/src/schema/loggableEvent/loggableEvent.graphql
@@ -160,7 +160,7 @@ input AddTimestampToEventMutationInput {
     """
     ID of the loggable event to add timestamp to
     """
-    eventId: ID!
+    id: ID!
 
     """
     ISO string timestamp to add to the event
@@ -190,7 +190,7 @@ input RemoveTimestampFromEventMutationInput {
     """
     ID of the loggable event to remove timestamp from
     """
-    eventId: ID!
+    id: ID!
 
     """
     ISO string timestamp to remove from the event


### PR DESCRIPTION
This pull request introduces several improvements to the GraphQL resolvers by leveraging authentication and ownership directives, simplifying error handling, and standardizing schema definitions. Additionally, it includes a new dependency for runtime invariant checks. Below is a breakdown of the most important changes:

### Dependency Addition
* Added the `tiny-invariant` library to enforce runtime checks and improve code safety (`package.json`).

### Improvements to `eventLabel` Resolvers
* Replaced manual user authentication checks with the `invariant` function to ensure the user is authenticated after the `@requireAuth` directive validation (`src/schema/eventLabel/index.ts`). [[1]](diffhunk://#diff-bf13471a3be7b10d60a65723fd518f86655193bf6acb5ace807a61606154e02dR1) [[2]](diffhunk://#diff-bf13471a3be7b10d60a65723fd518f86655193bf6acb5ace807a61606154e02dR37-R43)
* Removed redundant database existence checks for event labels, as the `@requireOwner` directive now ensures the label exists and is owned by the user (`src/schema/eventLabel/index.ts`). [[1]](diffhunk://#diff-bf13471a3be7b10d60a65723fd518f86655193bf6acb5ace807a61606154e02dL71-R74) [[2]](diffhunk://#diff-bf13471a3be7b10d60a65723fd518f86655193bf6acb5ace807a61606154e02dL116-R109)

### Improvements to `loggableEvent` Resolvers
* Standardized the ID field in schemas by replacing `eventId` with `id` for consistency in mutation inputs (`src/schema/loggableEvent/index.ts`, `src/schema/loggableEvent/loggableEvent.graphql`). [[1]](diffhunk://#diff-71e453896ee7e5a957348f134be5be599a7d29554f21beeb38b51a4c447beaffL36-R42) [[2]](diffhunk://#diff-b38752e4536e32ab31253e015afa5db570aa33a11d09bd01b8481f01a01c0d8eL163-R163) [[3]](diffhunk://#diff-b38752e4536e32ab31253e015afa5db570aa33a11d09bd01b8481f01a01c0d8eL193-R193)
* Simplified error handling by removing manual existence checks for loggable events and replacing them with `invariant` calls, as the authentication directive ensures the event exists and is owned by the user (`src/schema/loggableEvent/index.ts`). [[1]](diffhunk://#diff-71e453896ee7e5a957348f134be5be599a7d29554f21beeb38b51a4c447beaffL197-R210) [[2]](diffhunk://#diff-71e453896ee7e5a957348f134be5be599a7d29554f21beeb38b51a4c447beaffL238-R238)
* Updated helper function calls to align with the new standardized `id` field (`src/schema/loggableEvent/index.ts`).