### PR TITLE
Add labelIds to updateloggableevent mutation

### DIFF
--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -291,6 +291,8 @@ export type UpdateEventLabelMutationPayload = {
 export type UpdateLoggableEventMutationInput = {
     /** ID of the loggable event to update */
     id: Scalars['ID']['input'];
+    /** Array of label IDs to associate with this event */
+    labelIds?: InputMaybe<Array<Scalars['String']['input']>>;
     /** Updated name for the event (max 25 characters, cannot be empty) */
     name?: InputMaybe<Scalars['String']['input']>;
     /** Array of timestamps for this event */

--- a/src/schema/loggableEvent/loggableEvent.graphql
+++ b/src/schema/loggableEvent/loggableEvent.graphql
@@ -141,6 +141,11 @@ input UpdateLoggableEventMutationInput {
     Array of timestamps for this event
     """
     timestamps: [DateTime!]
+
+    """
+    Array of label IDs to associate with this event
+    """
+    labelIds: [String!]
 }
 
 """


### PR DESCRIPTION
This pull request introduces a dual-pattern error-handling system in the GraphQL API, adds label validation for `LoggableEvent` mutations, and updates the schema and resolver logic to support these changes. The most important updates include the addition of error-handling patterns, label ownership validation, and schema enhancements for label associations.

### Error Handling Enhancements:
* **README.md**: Documented two error-handling patterns: GraphQL Errors for critical issues (e.g., authentication failures) and API Errors for user-fixable issues (e.g., validation errors). Included examples and guidelines for when to use each pattern.

### Label Validation and Association:
* **`src/schema/loggableEvent/index.ts`**:
  - Added the `validateLabelOwnership` function to ensure provided `labelIds` exist and belong to the user. Throws a `GraphQLError` if validation fails.
  - Updated `createLoggableEvent` and `updateLoggableEvent` resolvers to validate `labelIds` and associate them with events when provided. [[1]](diffhunk://#diff-71e453896ee7e5a957348f134be5be599a7d29554f21beeb38b51a4c447beaffR122-R133) [[2]](diffhunk://#diff-71e453896ee7e5a957348f134be5be599a7d29554f21beeb38b51a4c447beaffL135-R195)
  - Enhanced input validation schema (`UpdateLoggableEventSchema`) to include `labelIds`.

### Schema Updates:
* **`src/schema/loggableEvent/loggableEvent.graphql`**: Extended the `UpdateLoggableEventMutationInput` type to include a `labelIds` field for associating labels with events.