### PR TITLE
Add validation for name uniqueness for labels and events

### DIFF
--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -46,7 +46,7 @@ export type AddTimestampToEventMutationPayload = {
 export type CreateEventLabelMutationInput = {
     /** Temporary ID for the label, used before creation. Will be replaced with the actual ID after creation. */
     id: Scalars['ID']['input'];
-    /** Name for the label (max 25 characters, cannot be empty) */
+    /** Name for the label (max 25 characters, cannot be empty, must be unique per user) */
     name: Scalars['String']['input'];
 };
 
@@ -67,7 +67,7 @@ export type CreateLoggableEventMutationInput = {
     id: Scalars['ID']['input'];
     /** Array of label IDs to associate with this event */
     labelIds?: InputMaybe<Array<Scalars['String']['input']>>;
-    /** Name for the event (max 25 characters, cannot be empty) */
+    /** Name for the event (max 25 characters, cannot be empty, must be unique per user) */
     name: Scalars['String']['input'];
     /** Number of days since the last event record before a warning will show for this event */
     warningThresholdInDays: Scalars['Int']['input'];
@@ -274,7 +274,7 @@ export type RemoveTimestampFromEventMutationPayload = {
 export type UpdateEventLabelMutationInput = {
     /** ID of the event label to update */
     id: Scalars['ID']['input'];
-    /** Updated name for the label (max 25 characters, cannot be empty) */
+    /** Updated name for the label (max 25 characters, cannot be empty, must be unique per user) */
     name?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -293,7 +293,7 @@ export type UpdateLoggableEventMutationInput = {
     id: Scalars['ID']['input'];
     /** Array of label IDs to associate with this event */
     labelIds?: InputMaybe<Array<Scalars['String']['input']>>;
-    /** Updated name for the event (max 25 characters, cannot be empty) */
+    /** Updated name for the event (max 25 characters, cannot be empty, must be unique per user) */
     name?: InputMaybe<Scalars['String']['input']>;
     /** Array of timestamps for this event */
     timestamps?: InputMaybe<Array<Scalars['DateTime']['input']>>;

--- a/src/schema/eventLabel/eventLabel.graphql
+++ b/src/schema/eventLabel/eventLabel.graphql
@@ -88,7 +88,7 @@ input CreateEventLabelMutationInput {
     id: ID!
 
     """
-    Name for the label (max 25 characters, cannot be empty)
+    Name for the label (max 25 characters, cannot be empty, must be unique per user)
     """
     name: String!
 }
@@ -103,7 +103,7 @@ input UpdateEventLabelMutationInput {
     id: ID!
 
     """
-    Updated name for the label (max 25 characters, cannot be empty)
+    Updated name for the label (max 25 characters, cannot be empty, must be unique per user)
     """
     name: String
 }

--- a/src/schema/loggableEvent/loggableEvent.graphql
+++ b/src/schema/loggableEvent/loggableEvent.graphql
@@ -103,7 +103,7 @@ input CreateLoggableEventMutationInput {
     id: ID!
 
     """
-    Name for the event (max 25 characters, cannot be empty)
+    Name for the event (max 25 characters, cannot be empty, must be unique per user)
     """
     name: String!
 
@@ -128,7 +128,7 @@ input UpdateLoggableEventMutationInput {
     id: ID!
 
     """
-    Updated name for the event (max 25 characters, cannot be empty)
+    Updated name for the event (max 25 characters, cannot be empty, must be unique per user)
     """
     name: String
 


### PR DESCRIPTION
This pull request introduces validation to ensure that `EventLabel` and `LoggableEvent` names are unique per user. It updates GraphQL schema definitions and resolver logic to enforce this constraint during creation and updates. The most important changes are grouped below by theme.

### Schema Updates

* Updated `name` field descriptions in `CreateEventLabelMutationInput` and `UpdateEventLabelMutationInput` to specify that names must be unique per user (`src/schema/eventLabel/eventLabel.graphql`). [[1]](diffhunk://#diff-897ed9e2402cbaad8b8c9502f0351a166d223dac27ab492e503442202ef953a6L91-R91) [[2]](diffhunk://#diff-897ed9e2402cbaad8b8c9502f0351a166d223dac27ab492e503442202ef953a6L106-R106)
* Updated `name` field descriptions in `CreateLoggableEventMutationInput` and `UpdateLoggableEventMutationInput` to specify that names must be unique per user (`src/schema/loggableEvent/loggableEvent.graphql`). [[1]](diffhunk://#diff-b38752e4536e32ab31253e015afa5db570aa33a11d09bd01b8481f01a01c0d8eL106-R106) [[2]](diffhunk://#diff-b38752e4536e32ab31253e015afa5db570aa33a11d09bd01b8481f01a01c0d8eL131-R131)

### Resolver Logic Updates

* Added validation in `createEventLabel` resolver to check if a label name already exists for the user before creating a new label (`src/schema/eventLabel/index.ts`).
* Added validation in `updateEventLabel` resolver to check for duplicate label names, excluding the current label being updated (`src/schema/eventLabel/index.ts`).
* Added validation in `createLoggableEvent` resolver to check if an event name already exists for the user before creating a new event (`src/schema/loggableEvent/index.ts`).
* Added validation in `updateLoggableEvent` resolver to check for duplicate event names, excluding the current event being updated (`src/schema/loggableEvent/index.ts`).